### PR TITLE
Fix build errors with ghc 9.6.1

### DIFF
--- a/Test/Apt.hs
+++ b/Test/Apt.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Apt (aptTests) where
+
+import Test.HUnit
+import Control.Exception
+import Data.Text (Text)
+import Debian.Apt.Index
+import Debian.Control
+
+aptTests :: [Test]
+aptTests = releaseIndexTests
+
+releaseIndexTests :: [Test]
+releaseIndexTests =
+    [ testReleaseIndexes e ps i | (i, (e, ps)) <- zip [1..]
+        [ ( Left "Invalid release file: "
+          , [] )
+        , ( Left "No indexes in release: No SHA256 Field, No SHA1 Field, No MD5Sum Field"
+          , [Paragraph []] )
+        , ( Left "No indexes in release: No SHA256 Field, No SHA1 Field, No MD5Sum Field"
+          , [Paragraph [Field ("x", "foo")]] )
+        , ( Left "No indexes in release: Invalid checksum line: \"abc\", Invalid checksum line: \"def\", Invalid checksum line: \"ghi\""
+          , [Paragraph [Field ("SHA256", "abc"), Field ("SHA1", "def"), Field ("MD5Sum", "ghi")]] )
+        , ( Left "No indexes in release: Invalid size field: \"123x\", No SHA1 Field, No MD5Sum Field"
+          , [Paragraph [Field ("SHA256", "abcde 123x file")]] )
+        , ( Right [(CheckSums {md5sum = Nothing, sha1 = Nothing, sha256 = Just "abcde"}, 123, "file")]
+          , [Paragraph [Field ("SHA256", "abcde 123 file")]] )
+        , ( Right [(CheckSums {md5sum = Just "abcde", sha1 = Nothing, sha256 = Nothing}, 123, "file")]
+          , [Paragraph [Field ("md5sum", "abcde 123 file")]] )
+        ]
+    ]
+
+testReleaseIndexes :: Either String [(CheckSums, Integer, FilePath)] -> [Paragraph' Text] -> Int -> Test
+testReleaseIndexes expected ps i = TestCase $
+    either (assertError pfx) (assertEqual pfx) expected
+        $ indexesInRelease (const True) (Control ps)
+    where pfx = "indexesInRelease" <> show i
+
+assertError :: (Eq a, Show a) => String -> String -> a -> Assertion
+assertError preface errExpected action = do
+    r <- try $ evaluate action
+    case r of
+        Left (ErrorCall err) -> assertEqual preface errExpected err
+        Right _ -> assertFailure $ preface <> " did not call error"

--- a/Test/Main.hs
+++ b/Test/Main.hs
@@ -2,15 +2,17 @@ module Main where
 
 import Test.HUnit
 import System.Exit
+import Apt
 import Changes
 import Control
+import Dependencies
 import Versions
 import Debian.Sources
-import Dependencies
 import Text.PrettyPrint
 
+main :: IO ()
 main =
-    do (c,st) <- runTestText putTextToShowS (TestList (versionTests ++ [sourcesListTests] ++ dependencyTests ++ changesTests ++ controlTests ++ prettyTests))
+    do (c,st) <- runTestText putTextToShowS (TestList (versionTests ++ [sourcesListTests] ++ dependencyTests ++ changesTests ++ controlTests ++ prettyTests ++ aptTests))
        putStrLn (st "")
        case (failures c) + (errors c) of
          0 -> return ()
@@ -18,6 +20,7 @@ main =
 
 -- | I was converting from one pretty printing package to another and
 -- was unclear how this should work.
+prettyTests :: [Test]
 prettyTests =
     [ TestCase (assertEqual
                 "pretty0"

--- a/debian.cabal
+++ b/debian.cabal
@@ -127,7 +127,8 @@ Test-Suite debian-tests
   Hs-Source-Dirs: Test
   Main-Is: Main.hs
  Build-Depends: base, Cabal, debian, HUnit, parsec, pretty >= 1.1.2, regex-tdfa, text
- other-modules: Changes
+ other-modules: Apt
+              , Changes
               , Control
               , Dependencies
               , Paths_debian

--- a/src/Debian/Apt/Methods.hs
+++ b/src/Debian/Apt/Methods.hs
@@ -25,6 +25,7 @@ import Debian.Time
 import Debian.URI (URI(..), parseURI, uriToString')
 
 import Control.Exception
+import Control.Monad (liftM, unless)
 import Control.Monad.Except
 import Data.Maybe
 import Data.Time

--- a/src/Debian/Control/ByteString.hs
+++ b/src/Debian/Control/ByteString.hs
@@ -30,6 +30,7 @@ import "mtl" Control.Monad.State
 
 import Data.Char(toLower, isSpace)
 import Data.List
+import Control.Monad (MonadPlus(..), ap, liftM, unless)
 
 import Text.ParserCombinators.Parsec.Error
 import Text.ParserCombinators.Parsec.Pos


### PR DESCRIPTION
* Add imports
* Handle loss of of `MonadPlus` instance for `Either String`
* Add tests for `indexesInRelease`

I tested the changes with ghc 8.6.5 too.